### PR TITLE
Linear regressions containing null y coordinates fail to produce accu…

### DIFF
--- a/src/regression.js
+++ b/src/regression.js
@@ -30,12 +30,26 @@
   /**
    * Determine the coefficient of determination (r^2) of a fit from the observations and predictions.
    *
+   * @param {Array<Array<number>>} data - Pairs of observed x-y values, including nulls
+   * @param {Array<Array<number>>} results - Pairs of observed predicted x-y values, including null predictions
+   *
    * @param {Array<Array<number>>} observations - Pairs of observed x-y values
    * @param {Array<Array<number>>} predictions - Pairs of observed predicted x-y values
    *
    * @return {number} - The r^2 value, or NaN if one cannot be calculated.
    */
-  function determinationCoefficient(observations, predictions) {
+  function determinationCoefficient(data, results) {
+    var observations = [];
+    var predictions = [];
+
+    // Remove predictive points for accurate fit
+    data.forEach( function (d, i) {
+      if (d[1] !== null) {
+        observations.push(d);
+        predictions.push(results[i]);
+      }
+    });
+
     var sum = observations.reduce(function (accum, observation) { return accum + observation[1]; }, 0);
     var mean = sum / observations.length;
 
@@ -136,6 +150,8 @@
       var gradient;
       var intercept;
       var len = data.length;
+      var nonNullLen = 0; // the number of non-null points
+
 
       for (var n = 0; n < len; n++) {
         if (data[n][1] !== null) {
@@ -144,11 +160,12 @@
           sum[2] += data[n][0] * data[n][0];
           sum[3] += data[n][0] * data[n][1];
           sum[4] += data[n][1] * data[n][1];
+          nonNullLen++;
         }
       }
 
-      gradient = (len * sum[3] - sum[0] * sum[1]) / (len  * sum[2] - sum[0] * sum[0]);
-      intercept = (sum[1] / len) - (gradient * sum[0]) / len;
+      gradient = (nonNullLen * sum[3] - sum[0] * sum[1]) / (nonNullLen  * sum[2] - sum[0] * sum[0]);
+      intercept = (sum[1] / nonNullLen) - (gradient * sum[0]) / nonNullLen;
 
       results = data.map(function (xyPair) {
         var x = xyPair[0];

--- a/tests/regression.js
+++ b/tests/regression.js
@@ -6,6 +6,7 @@ var regression = require('..');
 describe('regression', function () {
   var example = {
     diagLine: [[10, 20], [100, 200], [1000, 2000], [10000, 20000]],
+    nullDataDiagLine: [[10, 20], [100, null], [1000, 2000], [10000, null]],
     thirdSlopeLine: [[3, 2], [6, 3]],
     hline: [[10, 20], [20, 20]],
     negdiagline: [[10, -20], [100, -200], [1000, -2000], [10000, -20000]],
@@ -27,6 +28,14 @@ describe('regression', function () {
 
     it('should fit perfectly linear data correctly', function () {
       expect(linear(example.diagLine)).to.deep.equal({
+        r2: 1,
+        equation: [2, 0],
+        points: example.diagLine,
+        string: 'y = 2x + 0',
+      });
+    });
+    it('should predict fit for missing linear data correctly', function () {
+      expect(linear(example.nullDataDiagLine)).to.deep.equal({
         r2: 1,
         equation: [2, 0],
         points: example.diagLine,


### PR DESCRIPTION
Linear regressions containing null y coordinates fail to produce accurate results due to the length of the data not matching the 'len' used to run the calculations. This is solved by introducing a variable 'nonNullLen' which is an incrementer to keep track of all participating data.

In fixing the above, I discovered a similar problem with r2, causing the test to fail on r2. In order to fix that, we create two new data arrays of the matching participating points.